### PR TITLE
fixed typo in LotusDB struct description

### DIFF
--- a/db.go
+++ b/db.go
@@ -13,7 +13,7 @@ var (
 	ErrDefaultCfNil = errors.New("default column family is nil")
 )
 
-// LotusDB provide basic opetions for a persistent kv store.
+// LotusDB provide basic operations for a persistent kv store.
 // It`s methods(Put Get Delete) are self explanatory, and executed in default ColumnFamily.
 // You can create a custom ColumnFamily by calling method OpenColumnFamily.
 type LotusDB struct {


### PR DESCRIPTION
![Schermata da 2022-04-01 19-43-35](https://user-images.githubusercontent.com/49289653/161315188-50214659-bfd9-4d2c-aaa0-77debe0f6e2b.png)
