### PR TITLE
arena function GetBytes() add check offset logic

### DIFF
--- a/arenaskl/arena.go
+++ b/arenaskl/arena.go
@@ -98,6 +98,11 @@ func (a *Arena) GetBytes(offset uint32, size uint32) []byte {
 	if offset == 0 {
 		return nil
 	}
+
+	if offset >= a.Cap() || offset+size >= a.Cap() {
+		return nil
+	}
+
 	return a.buf[offset : offset+size]
 }
 


### PR DESCRIPTION
The function GetBytes() does not judge the situation that the offset is out of bounds.Add simple logic for detection.

- The scope of the change does not include:
Iterator : Value();
Skiplist : allocKey();
Skiplist : allocVal().

- The scope of the changes includes:
node : getKey().
method returns nil if not found.

please confirm～