### PR TITLE
fix size bug

### DIFF
--- a/memtable.go
+++ b/memtable.go
@@ -109,7 +109,7 @@ func (mt *memtable) put(key []byte, value []byte, deleted bool, opts WriteOption
 	}
 
 	buf, sz := logfile.EncodeEntry(entry)
-	if uint32(sz)+paddedSize >= mt.skl.Size() {
+	if uint32(sz)+paddedSize >= mt.skl.Arena().Cap() {
 		return ErrValueTooBig
 	}
 	// write entry into wal first.


### PR DESCRIPTION
correct `int32(sz)+paddedSize` to `mt.skl.Arena().Cap()`